### PR TITLE
Windows encoding inside RStudio help pane

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     V8,
     xml2,
     rvest,
-    rstudioapi,
     memoise,
     readr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,9 @@
+# rdocsyntax 0.5.2.9000
+
+## Changes
+
+- Use the `RSTUDIO` environment variable to check for RStudio usage. This also removes `rstudioapi` dependency ([#21](https://github.com/kiendang/rdocsyntax/pull/21)).
+
+## Bug fixes
+
+- Finally (hopefully) fixed encoding on Windows ([#6](https://github.com/kiendang/rdocsyntax/issues/6)) ([#21](https://github.com/kiendang/rdocsyntax/pull/21))

--- a/R/highlight.r
+++ b/R/highlight.r
@@ -6,7 +6,7 @@ highlight_html_file <- function(html, call_js = call_js_()) {
   highlight_html_tree(doc, call_js = call_js)
 
   out <- as.character(doc, options = c())
-  if (.Platform$OS.type == "windows" && rstudioapi::isAvailable()) {
+  if (.Platform$OS.type == "windows" && is_rstudio()) {
     Encoding(out) <- "unknown"
   }
   out
@@ -20,7 +20,7 @@ highlight_html <- function(html, call_js = call_js_()) {
   highlight_html_tree(doc, call_js = call_js)
 
   out <- as.character(doc, options = c())
-  if (.Platform$OS.type == "windows" && rstudioapi::isAvailable()) {
+  if (.Platform$OS.type == "windows" && is_rstudio()) {
     Encoding(out) <- "unknown"
   }
   out
@@ -28,7 +28,7 @@ highlight_html <- function(html, call_js = call_js_()) {
 
 
 highlight_html_tree <- function(doc, call_js = call_js_()) {
-  if (!rstudioapi::isAvailable()) {
+  if (!is_rstudio()) {
     theme <- get_user_theme(call_js = call_js)
     add_css(doc, theme$cssText)
     add_css(doc, if (theme$isDark) dark_css else light_css)
@@ -57,7 +57,7 @@ highlight_text <- function(s, call_js = call_js_()) {
 
 get_user_theme <- function(call_js = call_js_()) {
   if (
-    (!rstudioapi::isAvailable()) &&
+    (!is_rstudio()) &&
     length(theme <- getOption("rdocsyntax.theme")) &&
     is.character(theme)
   ) {

--- a/R/highlight.r
+++ b/R/highlight.r
@@ -1,6 +1,33 @@
-highlight_html <- function(html, encoding = "", call_js = call_js_()) {
-  doc <- read_html(html)
+highlight_html_file <- function(html, call_js = call_js_()) {
+  if (!file.exists(html))
+    stop(sprintf("file %s doesn't exists", html))
 
+  doc <- read_html(html)
+  highlight_html_tree(doc, call_js = call_js)
+
+  out <- as.character(doc, options = c())
+  if (.Platform$OS.type == "windows" && rstudioapi::isAvailable()) {
+    Encoding(out) <- "unknown"
+  }
+  out
+}
+
+
+highlight_html <- function(html, call_js = call_js_()) {
+  Encoding(html) <- "UTF-8"
+
+  doc <- read_html(html)
+  highlight_html_tree(doc, call_js = call_js)
+
+  out <- as.character(doc, options = c())
+  if (.Platform$OS.type == "windows" && rstudioapi::isAvailable()) {
+    Encoding(out) <- "unknown"
+  }
+  out
+}
+
+
+highlight_html_tree <- function(doc, call_js = call_js_()) {
   if (!rstudioapi::isAvailable()) {
     theme <- get_user_theme(call_js = call_js)
     add_css(doc, theme$cssText)
@@ -20,12 +47,6 @@ highlight_html <- function(html, encoding = "", call_js = call_js_()) {
   }
 
   replace_theme_css_class(doc, ace_default_css_class(), ace_generic_css_class())
-
-  highlighted_html <- as.character(doc, options = c(), encoding = encoding)
-
-  if (is.na(native <- iconv(highlighted_html, from = encoding, to = "")))
-    highlighted_html
-  else native
 }
 
 

--- a/R/httpd.r
+++ b/R/httpd.r
@@ -17,29 +17,26 @@ get_httpd <- function() {
 
 new_httpd <- function() {
   httpd <- get_original_httpd()
+  fileRegexp <- "^/library/+([^/]*)/html/([^/]*)\\.html$"
 
   function(path, ...) {
     response <- httpd(path, ...)
 
     if (grepl("^/(doc|library)/", path)) {
       tryCatch({
-        if (length(payload <- response[["payload"]]) && is_html_payload(response)) {
-          fileRegexp <- "^/library/+([^/]*)/html/([^/]*)\\.html$"
-
-          encoding <-
-            if (grepl(fileRegexp, path) && {
-              pkg <- sub(fileRegexp, "\\1", path)
-              length(enc <- packageDescription(pkg)[["Encoding"]])
-            } && enc == "UTF-8") "UTF-8" else native_encoding()
-
-          response[["payload"]] <-
-            highlight_html(payload, encoding = encoding, call_js = call_js_())
+        if (
+          length(payload <- response[["payload"]]) &&
+          is_html_payload(response) &&
+          grepl(fileRegexp, path)
+        ) {
+          response[["payload"]] <- highlight_html(payload, call_js = call_js_())
         } else if (
           length(file <- response[["file"]]) &&
-          (tolower(file_ext(file)) == "html" || is_html_file(response))
+          (tolower(file_ext(file)) == "html" || is_html_file(response)) &&
+          enable_extra()
         ) {
-          response[["file"]] <-
-            highlight_html(read_file(file), native_encoding(), call_js = call_js_())
+          response[["file"]] <- highlight_html_file(file, call_js = call_js_())
+
           names(response) <-
             ifelse(names(response) == "file", "payload", names(response))
         }

--- a/R/utils.r
+++ b/R/utils.r
@@ -49,3 +49,7 @@ native_encoding <- function() {
     "latin1"
   } else ""
 }
+
+is_rstudio <- function() {
+  Sys.getenv("RSTUDIO") == "1"
+}

--- a/R/utils.r
+++ b/R/utils.r
@@ -36,6 +36,10 @@ debugging <- function() {
   bool_option("rdocsyntax.dev")
 }
 
+enable_extra <- function() {
+  bool_option("rdocsyntax.extra")
+}
+
 native_encoding <- function() {
   l10n <- l10n_info()
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ options(rdocsyntax.theme = "dracula")
 
 The default theme is `textmate` in case `rdocsyntax.theme` is not set or set to an invalid value.
 
+### Vignette syntax highlighting
+
+Due to security reasons by default only code in `?` help pages is syntax highlighted. Syntax highlighting for other pages served by the dynamic help server `httpd` including vignettes can be enabled by setting
+
+```r
+options(rdocsyntax.extra = TRUE)
+```
+
+Code in most vignettes has already been highlighted by default without the need for `rdocsyntax`. However one might still want to enable `rdocsyntax` for vignettes so that the color scheme matches that of RStudio. This is particularly useful with dark RStudio themes since most vignettes use textmate color scheme, which is a light theme and not dark mode friendly, for syntax highlighting.
+
+`rdocsyntax.extra = TRUE` does not affect user defined `httpd` endpoints under `/custom/`, only those under `/doc/` abd `/library/`.
+
 ### Inline `## Not run`
 
 There are `## Not run` code examples that are single line. *e.g* in `?rstudioapi::highlightUi`

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ or Github
 remotes::install_github("kiendang/rdocsyntax")
 ```
 
-*__Warning__: Currently the package is not working reliably on windows. If the main branch does not work for you, you can try version `v0.5.2` `remotes::install_github("kiendang/rdocsyntax", ref = "v0.5.2")`. Neither version is confirmed to work 100%, however.*
-
 *__Note__: The package depends on the `V8` R package which depends on `libv8`. If you are on Linux you need to either install `libv8` from the package manager of your distro, compile `libv8` yourself or run the following commands to automatically download a suitable static build of `libv8` during installation of the `V8` R package (`>= 3.4`)*
 
 ```r

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,0 @@
-- Currently using a mix of `rvest` and `xml2`. Ideally we should only use `xml2`. The reasons why we need `rvest` in some places right now are:
-  - Some function(s) from `xml2` remove whitespaces by default. Need to figure out which one(s) and whether there are options to disable this.
-  - For certain queries CSS selector is much more straightforward than XPath, *e.g.* select nodes based on class.
-
-- ~~Figure out logging, *i.e.* log errors from `httpd` in dev/debug mode.~~
-
-- ~~Handle inline `## Not run:`, *i.e.* port over https://github.com/kiendang/rdocsyntax.ex#single-line--not-run~~
-
-- ~~Add tests~~


### PR DESCRIPTION
Fix #6 

## Overview

We highlight the docs by
1. getting the original html response returned by `httpd`
2. parsing the html (character) using `xml2`, applying highlighting then converting the parsed html back to character
3. displaying the highlighted doc inside RStudio help pane

Thus problems related to windows encoding of `?` docs displayed in RStudio help pane involve encoding in 3 different places:
1. how the original html returned by `httpd` is encoded
2. how encoding is handled by `xml2` during parsing and converting back to character
3. how RStudio handles the encoding of the highlighted html

## `?effectsize::cohens_d`

`?effectsize::cohens_d` has `’` wrongly displayed, either as `â€™` or `�`. Fixing this requires tracing through 3 places mentioned above.

`?` doc html returned by `httpd` is always encoded with `UTF-8`

https://github.com/wch/r-source/blob/db201da884088a20de2d0bc1ca835546bcd0188f/src/library/tools/R/dynamicHelp.R#L446-L450

```r
Rd2HTML(utils:::.getHelpFile(file.path(path, helpdoc)),
                 out = outfile, package = dirpath,
                 dynamic = TRUE)
on.exit(unlink(outfile))
return(list(payload = paste(readLines(outfile), collapse = "\n")))
```

`Rd2HTML` by default uses UTF-8 encoding.

However, R treats the encoding of this html returned by `httpd` as `unknown`, probably due to `readLines`

```r
> Encoding(tools:::httpd("/library/effectsize/html/cohens_d.html")$payload)
[1] 'unknown'
```

If this is left as is, `xml2::read_html` (which by default treat the input as encoded with UTF-8) will not encode non-ASCII characters probably, *e.g.* _they’re_ as _theyâ€™re_. What happens here is

> - theyâ€™re_ is _a UTF-8 string
> - converted from a Windows-1252 string, (_theyâ€™re_)
> - whose bytes should have been read as UTF-8 (_they’re_).

[this](https://stat545.com/character-encoding.html#how-to-get-from-theyare-to-theyre) and [this](https://www.justinweiss.com/articles/how-to-get-from-theyre-to-theyre/) explain more in details.

To solve this we need to set the correct encoding for the input html to UTF-8

```r
html <-tools:::httpd("/library/effectsize/html/cohens_d.html")$payload
Encoding(html) <- "UTF-8"
doc <- xml2::read_html(html)
... # highlight the doc
result <- as.character(doc, options = c())
```

However RStudio now displays `’` as `�` instead of `â€™`. This is because `result` now has encoding `UTF-8` and somehow RStudio does not handle it correctly. We need to revert back to `unknown` like the original response from `httpd`

```r
Encoding(result) <- "unknown"
```

Now `’` in `?effectsize::cohens_d` will be displayed correctly in Windows RStudio.

## em dash `–` in `?mtcars`

After apply highlighting `–` is displayed as `�` in RStudio help pane in Windows.

The original html for `?mtcars` returned by `httpd` actually has all ASCII characters. `–` was actually written using the html entity `&mdash`. However, `xml2` always converts some entities to UTF-8 characters. This combined with the same problem above with how RStudio handles encoding led to `�`. The same fix works here too, by reverting the encoding of the highlighted html string back to `unknown`.

## Summary

So this fix should make every case (that we know) work

1. set the `Encoding` of the original html returned by `httpd` to `UTF-8` before parsing with `xml2`
2. set the `Encoding` of the string converted from highlighted parsed html with `as.character` back to `unknown`